### PR TITLE
Add support joining a specific agent pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Run `ant dist` to create a dist for using with a TeamCity server distribution. R
 The following parameters can be used in the [build agent configuration](https://www.jetbrains.com/help/teamcity/build-agent-configuration.html) to test the functionality with the server:
   1. `autoAuthorize=true` for authorizing and unauthorizing agents on registration and unregistration events.
   1. `autoManage=true` for cleaning up agents in addition to authorization and unauthorization.
+  1. `agentPool=<poolName>` for specifing a non-default agent pool to join on auto-authorization event.
 
 # Server Configuration
 

--- a/src/mrtc/agentManagerListener/AutoAuthorizeListener.java
+++ b/src/mrtc/agentManagerListener/AutoAuthorizeListener.java
@@ -18,9 +18,13 @@ package mrtc.agentManagerListener;
 
 import java.util.*;
 
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.BuildServerAdapter;
 import jetbrains.buildServer.serverSide.SBuildAgent;
 import jetbrains.buildServer.serverSide.SBuildServer;
+import jetbrains.buildServer.serverSide.ServerListener;
+import jetbrains.buildServer.serverSide.agentPools.AgentPool;
+import jetbrains.buildServer.serverSide.agentPools.AgentPoolManager;
 import org.jetbrains.annotations.NotNull;
 
 
@@ -28,10 +32,13 @@ import org.jetbrains.annotations.NotNull;
  * Authorizes agents as soon as they're registered
  */
 public class AutoAuthorizeListener extends BuildServerAdapter {
+  private final static Logger LOG = Logger.getInstance(ServerListener.class.getName());
   private final SBuildServer myBuildServer;
+  private final AgentPoolManager myAgentPoolManager;
 
-  public AutoAuthorizeListener(SBuildServer sBuildServer) {
+  public AutoAuthorizeListener(SBuildServer sBuildServer, AgentPoolManager agentPoolManager) {
     myBuildServer = sBuildServer;
+    myAgentPoolManager = agentPoolManager;
   }
 
   public void register() {
@@ -43,6 +50,7 @@ public class AutoAuthorizeListener extends BuildServerAdapter {
     Map<String,String> parameters = sBuildAgent.getAvailableParameters();
     if ((parameters.containsKey("autoAuthorize") && parameters.get("autoAuthorize").equals("true")) ||
         (parameters.containsKey("autoManage") && parameters.get("autoManage").equals("true"))) {
+      moveAgentToPool(sBuildAgent);
       sBuildAgent.setAuthorized(true, null, "ASG agent registered");
     }
   }
@@ -53,6 +61,30 @@ public class AutoAuthorizeListener extends BuildServerAdapter {
     if ((parameters.containsKey("autoAuthorize") && parameters.get("autoAuthorize").equals("true")) ||
         (parameters.containsKey("autoManage") && parameters.get("autoManage").equals("true"))) {
       sBuildAgent.setAuthorized(false, null, "ASG agent unregistered");
+    }
+  }
+  
+  private void moveAgentToPool(@NotNull SBuildAgent sBuildAgent) {
+    Map<String,String> parameters = sBuildAgent.getAvailableParameters();
+
+    if (!parameters.containsKey("agentPool")) {
+      return;
+    }
+
+    final String agentPoolName = parameters.get("agentPool");
+    AgentPool agentPool = myAgentPoolManager.getAllAgentPools().stream()
+            .filter(pool -> pool.getName().equalsIgnoreCase(agentPoolName))
+            .findFirst().orElse(null);
+
+    if (agentPool == null) {
+      LOG.warn("Agent Pool '" + agentPoolName + "' could not be found. Agent will be registered in the default pool");
+      return;
+    }
+
+    try {
+      myAgentPoolManager.moveAgentTypesToPool(agentPool.getAgentPoolId(), Collections.singleton(sBuildAgent.getAgentTypeId()));
+    } catch (Exception e) {
+      LOG.error("Error assigning an agent to pool. Agent will be registered in the default pool " + e.toString());
     }
   }
 }

--- a/src/mrtc/agentManagerListener/AutoAuthorizeListener.java
+++ b/src/mrtc/agentManagerListener/AutoAuthorizeListener.java
@@ -77,7 +77,7 @@ public class AutoAuthorizeListener extends BuildServerAdapter {
             .findFirst().orElse(null);
 
     if (agentPool == null) {
-      LOG.warn("Agent Pool '" + agentPoolName + "' could not be found. Agent will be registered in the default pool");
+      LOG.warn(String.format("Agent Pool '%s' could not be found. Agent will be registered in the default pool", agentPool));
       return;
     }
 

--- a/teamcityagentmanager.xml
+++ b/teamcityagentmanager.xml
@@ -83,6 +83,7 @@
     <pathelement location="${path.variable.teamcitydistribution}/webapps/ROOT/WEB-INF/lib/annotations.jar"/>
     <pathelement location="${path.variable.teamcitydistribution}/webapps/ROOT/WEB-INF/lib/jdom.jar"/>
     <pathelement location="${path.variable.teamcitydistribution}/webapps/ROOT/WEB-INF/lib/openapi.jar"/>
+    <pathelement location="${path.variable.teamcitydistribution}/webapps/ROOT/WEB-INF/lib/server.jar"/>
     <pathelement location="${path.variable.teamcitydistribution}/webapps/ROOT/WEB-INF/lib/spring-webmvc.jar"/>
     <pathelement location="${path.variable.teamcitydistribution}/webapps/ROOT/WEB-INF/lib/spring.jar"/>
     <pathelement location="${path.variable.teamcitydistribution}/webapps/ROOT/WEB-INF/lib/util.jar"/>


### PR DESCRIPTION
Adds support for auto-joining a specific agent pool on registration. Useful for automatic management of multiple agent clusters on the same server.

Request has been made on the original plugin: https://plugins.jetbrains.com/plugin/9303-agent-auto-authroize/reviews

Inspiration from: http://svn.jetbrains.org/teamcity/plugins/agent-magic-authorize/trunk/server/src/agentMagicAuthorize/server/ServerListener.java

Note: I'm not very experienced with java/teamcity development, so all suggestions are welcome.